### PR TITLE
Task/id 305/send email only hermes

### DIFF
--- a/resources/verifyEmail.html
+++ b/resources/verifyEmail.html
@@ -202,7 +202,11 @@ table, td { color: #000000; } #u_body a { color: #0000ee; text-decoration: under
       <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:35px 55px 10px;font-family:arial,helvetica,sans-serif;" align="left">
         
   <div class="v-text-align v-font-size" style="font-size: 14px; color: #333333; line-height: 170%; text-align: left; word-wrap: break-word;">
-    <p style="font-size: 14px; line-height: 170%;"><span style="font-size: 18px; line-height: 30.6px; font-family: Lato, sans-serif;"><strong><span style="line-height: 30.6px; font-size: 18px;">Hi, </span></strong></span></p>
+    <p style="font-size: 14px; line-height: 170%;">
+      <span style="font-size: 18px; line-height: 30.6px; font-family: Lato, sans-serif;">
+          <strong>Hi,</strong> <span style="line-height: 30.6px; font-size: 18px;"><em>User</em></span>
+      </span>
+  </p>
 <p style="font-size: 14px; line-height: 170%;"> </p>
 <p style="font-size: 14px; line-height: 170%;"><span style="font-size: 16px; line-height: 27.2px;">Thank you for registering! Please use the following verification code:</span></p>
   </div>

--- a/src/controller/requests/sendEmailReq.js
+++ b/src/controller/requests/sendEmailReq.js
@@ -26,9 +26,9 @@ export const sendEmail = async (req, res) => {
   const { to, code } = req.query;
     const mailOptions = {
       from: 'hermes.info.app@gmail.com',
-      to: to,
+      to: 'hermes.info.app@gmail.com',
       subject: `Hermes email verification code: ` + code,
-      html: await getHtml('resources/verifyEmail.html', code)
+      html: await getHtml('resources/verifyEmail.html', code, to)
   };
 
   transporter.sendMail(mailOptions, (error, info) => {
@@ -48,7 +48,7 @@ export const sendEmail = async (req, res) => {
  * @param {string} codeEmail - The code to replace the placeholder with.
  * @returns {Promise<string>} A promise that resolves with the modified HTML content.
  */
-  function getHtml(route, codeEmail) {
+  function getHtml(route, codeEmail, to) {
     return new Promise((resolve, reject) => {
       fs.readFile(route, 'utf8', (err, data) => {
         if (err) {
@@ -56,7 +56,8 @@ export const sendEmail = async (req, res) => {
         } else {
           let contentData = data;
           let htmlString = contentData.replace("codeToRemplace", codeEmail);
-          resolve(htmlString);
+          let htmlStringData = htmlString.replace("User", to);
+          resolve(htmlStringData);
         }
       });
     });


### PR DESCRIPTION
What do I do?
Perform the part of only send email to hermes.info.app@gmail.com, an email only to receive email and send email.
How did I do that?
I did it with nodemailer, which this time will no longer send to the end user, but to the application hermes.info.app@gmail.com and from that email will be sent to the end user.
Why did I do it?
I did it with the objective that of all those who want to be administrators, only hermes.info.app@gmail.com will be able to send to the end user, if he authorizes it.
The credentials of hermes.info.app@gmail.com are available on the wiki 

![Screenshot from 2023-06-22 17-19-16](https://github.com/CampusDelSaber/api-rest-hermes/assets/135712226/6d7a2c6f-3f73-424d-bf9f-16ea5bedb7a6)

The flow of the programme is 
to enter the url: 
http://localhost:4000/send-email?to=yourEmail@ejemplo.com&code=3928

![image](https://github.com/CampusDelSaber/api-rest-hermes/assets/135712226/509a7660-6902-4882-9e3b-3c37a5db2f82)

You check if hermes.info.app@gmail.com received the email, which should look like this:
![image](https://github.com/CampusDelSaber/api-rest-hermes/assets/135712226/effa5cf5-ac70-4976-8528-c974909d873a)

- the change is to display the email address of who is applying to be an administrator.